### PR TITLE
Use casper.wait so that execution is synchronous

### DIFF
--- a/lib/wraith/javascript/casper.js
+++ b/lib/wraith/javascript/casper.js
@@ -70,7 +70,7 @@ function waitForLoad(callback) {
   }
 
   if (pending) {
-    setTimeout(function() { waitForLoad(callback); }, 500);
+    casper.wait(500, function() { waitForLoad(callback); });
   } else {
     callback();
   }


### PR DESCRIPTION
Fixes issues where a screenshot may not be captured if there is a slow resource to load.